### PR TITLE
Fixes non-rendering of html entities.

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -65,7 +65,7 @@ Ele will automatically name your package based on the first `polymer-element` yo
       
 Ele is designed to mirror as closely as possible environment of a reusable component distributed via Bower. To that end, we have made available Polymer, the `core-elements` and the `paper-elements` by using relative URLs. For example, if you want to use `core-ajax` in your element, you simply need to add the relevant `<link>` tag:
       
-    &lt;link rel="import" href="../core-ajax/core-ajax.html"&gt;
+    <link rel="import" href="../core-ajax/core-ajax.html">
 
 For now only the core and paper elements are available for import; however, we have hopes of making fully customizable bower dependencies a reality for Ele in the near future.
       


### PR DESCRIPTION
`<marked-element>` is not rendering `&lt;` and `&gt;` as `<`, and `>`.
